### PR TITLE
Update the layout of the View Request page

### DIFF
--- a/src/components/ViewRequest/ViewRequest.css
+++ b/src/components/ViewRequest/ViewRequest.css
@@ -1,34 +1,34 @@
 #viewRequestContainer {
   display: grid;
-  grid-template-columns: 5em 1fr 1fr;
-  grid-template-rows: 5em auto auto;
+  grid-template-columns: 5em 1fr;
+  grid-template-areas: 'action header'
+    'action details'
+    'action documents'
+    'action notes';
   column-gap: 0.5em;
   row-gap: 0.5em;
-  height: calc(100vh - 56px);
-  width: calc(100vw - 1em);
   margin: 0.5em;
 }
 
 #viewRequestActionBar {
-  grid-column-start: 1;
-  grid-row-start: 1;
-  grid-row-end: span 3;
+  grid-area: action;
+  position: fixed;
+  height: calc(100vh - 4.5em);
 }
 
 #viewRequestHeader {
-  grid-column-start: 2;
-  grid-column-end: span 3;
+  grid-area: header;
+  min-height: 5em;
 }
 
 #viewRequestDocuments {
-  grid-column-start: 3;
-  grid-row-start: 2;
-  grid-row-end: span 2;
+  grid-area: documents;
+  min-height: 5em;
 }
 
 #viewRequestNotes {
-  grid-column-start: 2;
-  grid-row-start: 3;
+  grid-area: notes;
+  min-height: 5em;
 }
 
 .gray-gradiant {
@@ -39,8 +39,22 @@
   padding: 0.25em;
 }
 
+#viewRequestDetailsContainer {
+  grid-area: details;
+}
+
 .viewRequestDetails {
   display: grid;
-  grid-template-columns: auto auto;
+  grid-template-columns: auto 1fr;
   row-gap: 0.5em;
+  column-gap: 1em;
+}
+
+@media (min-width: 1024px) {
+  #viewRequestContainer {
+    grid-template-columns: 5em 1fr 1fr;
+    grid-template-areas: 'action header header'
+      'action details documents'
+      'action notes documents';
+  }
 }

--- a/src/components/ViewRequest/ViewRequest.tsx
+++ b/src/components/ViewRequest/ViewRequest.tsx
@@ -10,7 +10,7 @@ const ViewRequest = () => {
       <section id="viewRequestHeader" className="gray-gradiant">
         Request Header
       </section>
-      <section>
+      <section id="viewRequestDetailsContainer">
         <ViewRequestDetails />
       </section>
       <section id="viewRequestNotes" className="gray-gradiant">


### PR DESCRIPTION
1)  Make this page dynamic so when screen is less than 1024px in width, it will put the Docments below the Details instead of to the right
2)  Make the different details sections (which use className "viewRequestDetails" to have the fieldname sized to fit the name of the field, and allow the data value to consume the rest of the space instead of sharing the space 50/50
3)  Make the Action bar a static element on the left, so it will always be visible even when scrolling